### PR TITLE
Use first image as display image in content if there is no thumbnail image.

### DIFF
--- a/includes/content_functions.php
+++ b/includes/content_functions.php
@@ -1,0 +1,24 @@
+<?
+/*
+ * Description: include supporting functions for WP Parallax Content Slider
+ * Licence: GPLv2
+ * Contributor: Chun Law
+ * Contribution: 	function has_content_image() and get_content_image_urls
+ *
+*/
+
+	function has_content_image() {
+		// match out all image tags in post content
+		$output = preg_match_all('/<img.+?src=[\'"]([^\'"]+)[\'"].*?>/', get_the_content() , $matches);
+		if(empty($matches [1])){ //Defines a default image
+			return false;
+		}
+		return true;
+	}
+
+	function get_content_image_urls(){
+		$output = preg_match_all('/<img.+?src=[\'"]([^\'"]+)[\'"].*?>/', get_the_content(), $matches);
+		// return array of urls
+		return $matches [1];
+	}
+?>

--- a/wp-parallax-content-slider.php
+++ b/wp-parallax-content-slider.php
@@ -7,7 +7,15 @@
  * Author: Julien Le Thuaut (MBA Multimedia)
  * Version: 1.0-dev
  * Licence: GPLv2
+ *
+ * Contributor: Chun Law
+ * Contribution: 	Use first image in content if there is no thumbnail image.
+ *					If no image in content, use default image
+ *
 */
+
+include_once plugin_dir_path( __FILE__ ) .'includes/content_functions.php';
+
 class WpParallaxContentSlider
 {
 	public $pluginUrl = '';
@@ -284,12 +292,17 @@ class WpParallaxContentSlider
 		while ( $myposts->have_posts() ) : $myposts->the_post();
 
 			// $custom = get_post_custom($post->ID);
-
+						
 			// Display the post thumbnail if there is one (Thank you John)
 			if ( has_post_thumbnail() ) {
 				$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'medium' );
 				$url = $thumb['0'];
 				$default_slide_image = $url;
+			}
+			else if ( has_content_image( ) != '' ){
+			//	echo get_content_image_urls( get_the_content() );
+				$temp = get_content_image_urls( );
+				$default_slide_image = $temp[0];
 			}
 
 			if ($prlx_text_content === 'excerpt') {


### PR DESCRIPTION
Apart from using thumbnail image, it is nice if image in content can be auto detected and pick as display. 
If both of them are missing, just use default image.

The setting is basically for theme that does not support thumbnail and make the plugin depend more on the post.

I have added one file which contains the functions used.

Thank you
