### PR TITLE
fixed notice from wordpress with register_uninstall_hook

### DIFF
--- a/wp-parallax-content-slider.php
+++ b/wp-parallax-content-slider.php
@@ -30,7 +30,7 @@ class WpParallaxContentSlider
 		// Register hooks that are fired when the plugin is activated, deactivated, and uninstalled, respectively.
 		register_activation_hook( __FILE__, array( $this, 'activate' ) );
 		//register_deactivation_hook( __FILE__, array( $this, 'uninstall' ) ); // TODO: Doing this on deactivation should require an extra parameter (user choice)
-		register_uninstall_hook( __FILE__, array( $this, 'uninstall' ) );
+		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
 
 		// Parallax slider plugin specific actions
 		add_action( 'admin_menu',  array( $this, 'admin_menu' ) );


### PR DESCRIPTION
thrown notice:

Notice: register_uninstall_hook was called <strong>incorrectly</strong>. Only a static class method or function can be used in an uninstall hook. Please see <a href="http://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.1.) in \wordpress\wp-includes\functions.php on line 2959
