### PR TITLE
Add image dimension calculation and image alt based on post title

### DIFF
--- a/wp-parallax-content-slider.php
+++ b/wp-parallax-content-slider.php
@@ -298,6 +298,8 @@ class WpParallaxContentSlider
 				$thumb = wp_get_attachment_image_src( get_post_thumbnail_id( $post->ID ), 'medium' );
 				$url = $thumb['0'];
 				$default_slide_image = $url;
+                                $image_width = $thumb['1'];
+                                $image_height = $thumb['2'];
 			}
 			else if ( has_content_image( ) != '' ){
 			//	echo get_content_image_urls( get_the_content() );
@@ -310,12 +312,16 @@ class WpParallaxContentSlider
 															get_the_excerpt(),
 															get_permalink(),
 															$default_slide_image,
+															$image_width,
+                                                                                                                        $image_height,
 															$prlx_title_max_chars )."\n";
 			} else {
 				$outputDynamic .= $this->get_article_slide( get_the_title(),
 															get_the_content(),
 															get_permalink(),
 															$default_slide_image,
+															$image_width,
+                                                                                                                        $image_height,
 															$prlx_title_max_chars )."\n";
 			}
 
@@ -351,12 +357,14 @@ DYNAMICOUTPUT;
 	/*
 	 * Generate HTML output for an article slide
 	 */
-	function get_article_slide( $title, $excerpt, $link_article, $url_image, $title_length, $alt_image = 'Alternative text' )
+	function get_article_slide( $title, $excerpt, $link_article, $url_image, $title_length, $image_width, $image_height, $alt_image = 'Alternative text' )
 	{
 		// Parameters
 		if ( strlen( $title ) > $title_length ) $title = mb_substr( $title, 0, $title_length ) . "...";
 
 		$title = apply_filters( 'prlx_slide_title', $title, get_the_title() );
+
+		$alt_image = $title;
 
 		// Slide output
 		$outputSlide  = "<div class='da-slide'>"."\n";

--- a/wp-parallax-content-slider.php
+++ b/wp-parallax-content-slider.php
@@ -371,7 +371,7 @@ DYNAMICOUTPUT;
 		$outputSlide .= "<h2>".$title."</h2>"."\n";
 		$outputSlide .= "<p>".$excerpt."</p>"."\n";
 		$outputSlide .= "<a href='".$link_article."' class='da-link'>" . __( 'Read more', 'wp-parallax-content-slider' ) . "</a>"."\n";
-		$outputSlide .= "<div class='da-img'><img src='".$url_image."' alt='".$alt_image."' /></div>"."\n";
+		$outputSlide .= "<div class='da-img'><img src='".$url_image."' alt='".$alt_image."' width='".$image_width."' height='".$image_height."'  /></div>"."\n";
 		$outputSlide .= "</div>"."\n";
 
 		$outputSlide = apply_filters( 'prlx_slide_content', $outputSlide, $this );


### PR DESCRIPTION
Salut,
Je ne suis pas dévelopeur, donc il est possible que ce que j'ai fait soit améliorable.
J'ai ajouter le calcul des dimensions de l'image pour de meilleures performances web et j'ai mis le titre du post en tant qu'attribut alt de l'image ce qui est mieux pour le référencement.
Je pense qu'il est mieux d'avoir le titre du post plutôt que "Alternative text"
Je n'ai pas touché à " $alt_image = 'Alternative text' " parce que je ne sais pas si il y a une méthode pour trouver l'attribut alt d'une image mise en avant (featured image)
D'ailleurs je ne sais pas si il y a un contenu alt pour ça ;)
J'ai traduit en anglais au cas où d'autres personnes souhaiterais savoir ce que fait cette modif.
Bonne journée
Pierre-Yves

Hi,
I am not a developer, so it's possible that what I did is improvable.
I' ve add image dimension calculation to better web performance and image alt based on post title to a better SEO
I think it is better to have the title of the article as an alt rather than "Alternative text" for SEO.
I didn't touch $alt_image = 'Alternative text' because I do not know if there is a method to find the alt of the featured image.
Best Regards,
Pierre-Yves
